### PR TITLE
Revised OpenACC approach in SAtransform IJK loop

### DIFF
--- a/ncar_scripts/derecho_a100_submit.sh
+++ b/ncar_scripts/derecho_a100_submit.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -l
 #PBS -N SAMURAI
 #PBS -A NTDD0004
-#PBS -l select=1:ncpus=64:ompthreads=1:mem=480GB:ngpus=1
+#PBS -l select=1:ncpus=64:ompthreads=1:mem=100GB:ngpus=1
 #PBS -q main
-#PBS -l walltime=00:30:00
+#PBS -l walltime=02:30:00
 #PBS -j oe
 #PBS -k eod
  


### PR DESCRIPTION
This PR modifies the OpenACC approach for (IJK) loop of the SAtransform operator.  While this reduces the amount of available parallelism for the Beltrami test case, it significantly increases it for the larger more realistic supercell and hurricane test cases.