### PR TITLE
Update ncar_run.sh, casper_a100_submit.sh, derecho_a100_submit.sh, hurricane_4panel.tdrp. Create casper_h100_submit.sh

### DIFF
--- a/ncar_scripts/TDRP/hurricane_4panel.tdrp
+++ b/ncar_scripts/TDRP/hurricane_4panel.tdrp
@@ -168,7 +168,7 @@ projection = PROJ_TRANSVERSE_MERCATOR_EXACT;
 //
 // Type: string
 
-data_directory = "/glade/campaign/cisl/asap/samurai/data/special/hurricane";
+data_directory = "/glade/campaign/cisl/asap/samurai/data/special/hurricane_4panel";
 
 ///////////// output_directory ////////////////////////
 //

--- a/ncar_scripts/casper_a100_submit.sh
+++ b/ncar_scripts/casper_a100_submit.sh
@@ -16,6 +16,9 @@ ID=`date '+%Y%m%d%H%M'`
 ##################
 # Build the code #
 ##################
+sed -i 's/cc70/cc80/g' CMakeLists.txt
+sed -i 's/cc90/cc80/g' CMakeLists.txt
+
 
 cd ncar_scripts 
 ./ncar_build.sh gpu

--- a/ncar_scripts/casper_h100_submit.sh
+++ b/ncar_scripts/casper_h100_submit.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -l
+#PBS -N SAMURAI
+#PBS -A NEOL0013
+#PBS -l select=1:ncpus=36:ompthreads=1:mem=700GB:ngpus=1
+#PBS -l gpu_type=h100
+#PBS -q casper
+#PBS -l walltime=05:00:00
+#PBS -j oe
+#PBS -k eod
+ 
+cd $PBS_O_WORKDIR
+cd ..
+export SAMURAI_ROOT=$(pwd)
+
+ID=`date '+%Y%m%d%H%M'`
+##################
+# Build the code #
+##################
+# Use cc90 for h100 GPU on Casper
+sed -i 's/cc80/cc90/g' CMakeLists.txt
+sed -i 's/cc70/cc90/g' CMakeLists.txt
+
+cd ncar_scripts 
+./ncar_build.sh gpu
+
+##############
+# Run a case #
+##############
+suffix="casper_gpu"
+for i in beltrami supercell hurricane typhoonChanthu2020  # hurricane_4panel
+
+do
+  ./ncar_run.sh $SAMURAI_ROOT/ncar_scripts/TDRP/${i}.tdrp >& log_${i}_$suffix.$ID
+  if [ ! -d  ${i}_${suffix} ]; then
+     mkdir ${i}_${suffix}
+  fi
+  mv $SAMURAI_ROOT/run/timing.0 ${i}_${suffix}/timing.$ID
+  mv $SAMURAI_ROOT/run/samurai* log* ${i}_${suffix}
+done

--- a/ncar_scripts/derecho_a100_submit.sh
+++ b/ncar_scripts/derecho_a100_submit.sh
@@ -15,6 +15,10 @@ ID=`date '+%Y%m%d%H%M'`
 ##################
 # Build the code #
 ##################
+sed -i 's/cc70/cc80/g' CMakeLists.txt
+sed -i 's/cc90/cc80/g' CMakeLists.txt
+
+
 cd ncar_scripts 
 ./ncar_build.sh gpu
 

--- a/ncar_scripts/derecho_a100_submit.sh
+++ b/ncar_scripts/derecho_a100_submit.sh
@@ -18,7 +18,6 @@ ID=`date '+%Y%m%d%H%M'`
 sed -i 's/cc70/cc80/g' CMakeLists.txt
 sed -i 's/cc90/cc80/g' CMakeLists.txt
 
-
 cd ncar_scripts 
 ./ncar_build.sh gpu
 

--- a/ncar_scripts/ncar_run.sh
+++ b/ncar_scripts/ncar_run.sh
@@ -31,6 +31,7 @@ if [ "${GPU}" == "0" ]; then
       export OMP_NUM_THREADS=128
    fi
 else
+  nvidia-smi
   echo "GPU run; using 1 thread and 1 GPU"
   export OMP_NUM_THREADS=1
 fi


### PR DESCRIPTION
Updated ncar_run to include "nvidia-smi". This will allow the top of each log file to include information regarding type of node ran on, date run, memory usage, driver, cuda, etc.