### PR TITLE
Fix the badge issue showing "unknown" status

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/github/mmbell/samurai/graph/badge.svg?token=YI7nJHhUCX)](https://codecov.io/github/mmbell/samurai)
+[![codecov](https://codecov.io/github/mmbell/samurai/branch/main/graph/badge.svg?token=YI7nJHhUCX)](https://codecov.io/github/mmbell/samurai/branch/main)
 
 # SAMURAI
 


### PR DESCRIPTION
This PR fixes the `unknown` status shown in the badge of the README page.