### PR TITLE
Read obMetaSize from TDRP config file

### DIFF
--- a/ncar_scripts/TDRP/beltrami.tdrp
+++ b/ncar_scripts/TDRP/beltrami.tdrp
@@ -113,6 +113,14 @@ mode = MODE_XYZ;
 
 analysis_type = WIND;
 
+///////////// obMetaSize //////////////////////////////
+//
+// number of meta-data associated with each observation
+//
+// Type: int
+
+obMetaSize = 7;
+
 ///////////// projection //////////////////////////////
 //
 // Projection.

--- a/ncar_scripts/TDRP/beltramiTR.tdrp
+++ b/ncar_scripts/TDRP/beltramiTR.tdrp
@@ -113,6 +113,14 @@ mode = MODE_XYZ;
 
 analysis_type = THERMO;
 
+///////////// obMetaSize //////////////////////////////
+//
+// number of meta-data associated with each observation
+//
+// Type: int
+
+obMetaSize = 7;
+
 ///////////// projection //////////////////////////////
 //
 // Projection.

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -126,6 +126,7 @@ bool Args::paramsToHash(HashMap *configHash) {
   
   // int arguments
 
+  CONFIG_INSERT_INT(obMetaSize);
   CONFIG_INSERT_INT(bkgd_kd_num_neighbors);
   CONFIG_INSERT_INT(debug_kd);
   CONFIG_INSERT_INT(debug_kd_step);

--- a/src/CostFunction3D.cpp
+++ b/src/CostFunction3D.cpp
@@ -149,8 +149,7 @@ void CostFunction3D::initialize(HashMap* config,
 
   /* Set the number of meta-data associated with each observation */
   obMetaSize = std::stoi((*configHash)["obMetaSize"]);
-  std::cout << "obMetaSize: " << obMetaSize << std::endl;
-  
+
   //JMD TODO:  Need to plug in the Thermo boundary conditions here.  
   //JMD        Currently this is only the wind boundary condidtions.
   // Horizontal boundary conditions
@@ -252,11 +251,6 @@ void CostFunction3D::initialize(HashMap* config,
   CTHTd      = new real[nState];
   stateU     = new real[nState];
   int64_t vector_size = mObs*(obMetaSize+varDim*derivDim);
-  std::cout << "vector_size: " << vector_size << std::endl;
-  std::cout << "mObs: " << mObs << std::endl;
-  std::cout << "obMetaSize: " << obMetaSize << std::endl;
-  std::cout << "varDim: " << varDim << std::endl;
-  std::cout << "derivDim: " << derivDim << std::endl;
   obsVector  = new real[vector_size];
   obsData    = new real[mObs];
   HCq        = new real[mObs+nodes];

--- a/src/CostFunction3D.cpp
+++ b/src/CostFunction3D.cpp
@@ -141,13 +141,16 @@ void CostFunction3D::initialize(HashMap* config,
   // Initialize number of variables
   varDim     = 7;
   derivDim   = 4;
-  obMetaSize = 7;
   configHash = config;
 
   /* Set the output path */
 	dataPath = (*configHash)["data_directory"];
   outputPath = (*configHash)["output_directory"];
 
+  /* Set the number of meta-data associated with each observation */
+  obMetaSize = std::stoi((*configHash)["obMetaSize"]);
+  std::cout << "obMetaSize: " << obMetaSize << std::endl;
+  
   //JMD TODO:  Need to plug in the Thermo boundary conditions here.  
   //JMD        Currently this is only the wind boundary condidtions.
   // Horizontal boundary conditions
@@ -249,6 +252,11 @@ void CostFunction3D::initialize(HashMap* config,
   CTHTd      = new real[nState];
   stateU     = new real[nState];
   int64_t vector_size = mObs*(obMetaSize+varDim*derivDim);
+  std::cout << "vector_size: " << vector_size << std::endl;
+  std::cout << "mObs: " << mObs << std::endl;
+  std::cout << "obMetaSize: " << obMetaSize << std::endl;
+  std::cout << "varDim: " << varDim << std::endl;
+  std::cout << "derivDim: " << derivDim << std::endl;
   obsVector  = new real[vector_size];
   obsData    = new real[mObs];
   HCq        = new real[mObs+nodes];

--- a/src/Params.cc
+++ b/src/Params.cc
@@ -748,8 +748,8 @@
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = ENUM_TYPE;
     tt->param_name = tdrpStrDup("analysis_type");
-    tt->descr = tdrpStrDup("Analysis type");
-    tt->help = tdrpStrDup("");
+    tt->descr = tdrpStrDup("Type of analysis to perform");
+    tt->help = tdrpStrDup("TODO");
     tt->val_offset = (char *) &analysis_type - &_start_;
     tt->enum_def.name = tdrpStrDup("analysis_type_t");
     tt->enum_def.nfields = 3;

--- a/src/Params.cc
+++ b/src/Params.cc
@@ -741,15 +741,15 @@
       tt->enum_def.fields[1].val = MODE_RTZ;
     tt->single_val.e = MODE_XYZ;
     tt++;
-
+    
     // Parameter 'analysis_type'
     // ctype is '_analysis_type_t'
     
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = ENUM_TYPE;
     tt->param_name = tdrpStrDup("analysis_type");
-    tt->descr = tdrpStrDup("Type of analysis to perform");
-    tt->help = tdrpStrDup("TODO");
+    tt->descr = tdrpStrDup("Analysis type");
+    tt->help = tdrpStrDup("");
     tt->val_offset = (char *) &analysis_type - &_start_;
     tt->enum_def.name = tdrpStrDup("analysis_type_t");
     tt->enum_def.nfields = 3;
@@ -763,7 +763,18 @@
       tt->enum_def.fields[2].val = WIND_THERMO;
     tt->single_val.e = WIND;
     tt++;
-
+    
+    // Parameter 'obMetaSize'
+    // ctype is 'int'
+    
+    memset(tt, 0, sizeof(TDRPtable));
+    tt->ptype = INT_TYPE;
+    tt->param_name = tdrpStrDup("obMetaSize");
+    tt->descr = tdrpStrDup("number of meta-data associated with each observation");
+    tt->help = tdrpStrDup("");
+    tt->val_offset = (char *) &obMetaSize - &_start_;
+    tt->single_val.i = -999;
+    tt++;
     
     // Parameter 'projection'
     // ctype is '_projection_t'
@@ -2999,7 +3010,7 @@
       tt->array_vals[0].f = -1;
       tt->array_vals[1].f = -1;
     tt++;
-
+    
     // Parameter 'Comment 15'
     
     memset(tt, 0, sizeof(TDRPtable));
@@ -3008,7 +3019,7 @@
     tt->comment_hdr = tdrpStrDup("VARIABLES NEEDED BY THERMO");
     tt->comment_text = tdrpStrDup("");
     tt++;
-
+    
     // Parameter 'i_pip_bcL'
     // ctype is 'int'
     
@@ -3020,9 +3031,10 @@
     tt->val_offset = (char *) &i_pip_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'i_pip_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("i_pip_bcR");
@@ -3031,9 +3043,10 @@
     tt->val_offset = (char *) &i_pip_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'i_thetarhop_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("i_thetarhop_bcL");
@@ -3042,9 +3055,10 @@
     tt->val_offset = (char *) &i_thetarhop_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'i_thetarhop_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("i_thetarhop_bcR");
@@ -3053,9 +3067,10 @@
     tt->val_offset = (char *) &i_thetarhop_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'i_ftheta_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("i_ftheta_bcL");
@@ -3064,9 +3079,10 @@
     tt->val_offset = (char *) &i_ftheta_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'i_ftheta_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("i_ftheta_bcR");
@@ -3075,7 +3091,7 @@
     tt->val_offset = (char *) &i_ftheta_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_pip_bcL'
     // ctype is 'int'
     
@@ -3087,9 +3103,10 @@
     tt->val_offset = (char *) &j_pip_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_pip_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("j_pip_bcR");
@@ -3098,9 +3115,10 @@
     tt->val_offset = (char *) &j_pip_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_thetarhop_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("j_thetarhop_bcL");
@@ -3109,9 +3127,10 @@
     tt->val_offset = (char *) &j_thetarhop_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_thetarhop_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("j_thetarhop_bcR");
@@ -3120,9 +3139,10 @@
     tt->val_offset = (char *) &j_thetarhop_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_ftheta_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("j_ftheta_bcL");
@@ -3131,9 +3151,10 @@
     tt->val_offset = (char *) &j_ftheta_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'j_ftheta_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("j_ftheta_bcR");
@@ -3142,7 +3163,7 @@
     tt->val_offset = (char *) &j_ftheta_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_pip_bcL'
     // ctype is 'int'
     
@@ -3154,9 +3175,10 @@
     tt->val_offset = (char *) &k_pip_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_pip_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("k_pip_bcR");
@@ -3165,9 +3187,10 @@
     tt->val_offset = (char *) &k_pip_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_thetarhop_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("k_thetarhop_bcL");
@@ -3176,9 +3199,10 @@
     tt->val_offset = (char *) &k_thetarhop_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_thetarhop_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("k_thetarhop_bcR");
@@ -3187,9 +3211,10 @@
     tt->val_offset = (char *) &k_thetarhop_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_ftheta_bcL'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("k_ftheta_bcL");
@@ -3198,9 +3223,10 @@
     tt->val_offset = (char *) &k_ftheta_bcL - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // Parameter 'k_ftheta_bcR'
     // ctype is 'int'
+    
     memset(tt, 0, sizeof(TDRPtable));
     tt->ptype = INT_TYPE;
     tt->param_name = tdrpStrDup("k_ftheta_bcR");
@@ -3209,7 +3235,7 @@
     tt->val_offset = (char *) &k_ftheta_bcR - &_start_;
     tt->single_val.i = -999;
     tt++;
-
+    
     // trailing entry has param_name set to NULL
     
     tt->param_name = NULL;

--- a/src/Params.hh
+++ b/src/Params.hh
@@ -408,6 +408,8 @@ public:
 
   analysis_type_t analysis_type;
 
+  int obMetaSize;
+
   projection_t projection;
 
   char* data_directory;
@@ -767,7 +769,7 @@ public:
   int i_ftheta_bcL;
 
   int i_ftheta_bcR;
- 
+
   int j_pip_bcL;
 
   int j_pip_bcR;
@@ -778,7 +780,7 @@ public:
 
   int j_ftheta_bcL;
 
-  int j_ftheta_bcR; 
+  int j_ftheta_bcR;
 
   int k_pip_bcL;
 
@@ -799,7 +801,7 @@ private:
 
   void _init();
 
-  mutable TDRPtable _table[210];
+  mutable TDRPtable _table[212];
 
   const char *_className;
 

--- a/src/Params.hh
+++ b/src/Params.hh
@@ -801,7 +801,7 @@ private:
 
   void _init();
 
-  mutable TDRPtable _table[212];
+  mutable TDRPtable _table[211];
 
   const char *_className;
 

--- a/src/VarDriver3D.cpp
+++ b/src/VarDriver3D.cpp
@@ -33,6 +33,7 @@ VarDriver3D::VarDriver3D() : VarDriver()
 {
   numVars = 7;          // Number of variables on which to perform the anslysis
   numDerivatives = 4;
+  obMetaSize = -1;      // Size of the observation Meta data; set by the TDRP config file
   bkgdAdapter = NULL;
   bgU = NULL;
   bgWeights = NULL;
@@ -103,6 +104,7 @@ bool VarDriver3D::validateDriver()
 
    // Print the analysis_type from the TDRP config file
    std::cout << "Analysis type: " << configHash["analysis_type"] << std::endl;
+   obMetaSize = std::stoi(configHash["obMetaSize"]);
    // Print the obMetaSize from the TDRP config file
    std::cout << "obMetaSize: " << configHash["obMetaSize"] << std::endl;
    if(configHash["analysis_type"] != "WIND")

--- a/src/VarDriver3D.cpp
+++ b/src/VarDriver3D.cpp
@@ -33,7 +33,6 @@ VarDriver3D::VarDriver3D() : VarDriver()
 {
   numVars = 7;          // Number of variables on which to perform the anslysis
   numDerivatives = 4;
-  obMetaSize = 7;       // Size of the observation Meta data
   bkgdAdapter = NULL;
   bgU = NULL;
   bgWeights = NULL;
@@ -105,7 +104,7 @@ bool VarDriver3D::validateDriver()
    // Print the analysis_type from the TDRP config file
    std::cout << "Analysis type: " << configHash["analysis_type"] << std::endl;
    // Print the obMetaSize from the TDRP config file
-   std::cout << "obMetaSize: " << obMetaSize << std::endl;
+   std::cout << "obMetaSize: " << configHash["obMetaSize"] << std::endl;
    if(configHash["analysis_type"] != "WIND")
    {
 	   std::cout << "i_pip_bcL = " << configHash["i_pip_bcL"] << std::endl;

--- a/src/VarDriver3D.cpp
+++ b/src/VarDriver3D.cpp
@@ -103,7 +103,9 @@ bool VarDriver3D::validateDriver()
   }
 
    // Print the analysis_type from the TDRP config file
-  std::cout << "Analysis type: " << configHash["analysis_type"] << std::endl;
+   std::cout << "Analysis type: " << configHash["analysis_type"] << std::endl;
+   // Print the obMetaSize from the TDRP config file
+   std::cout << "obMetaSize: " << obMetaSize << std::endl;
    if(configHash["analysis_type"] != "WIND")
    {
 	   std::cout << "i_pip_bcL = " << configHash["i_pip_bcL"] << std::endl;

--- a/src/paramdef.samurai
+++ b/src/paramdef.samurai
@@ -114,6 +114,12 @@ paramdef enum analysis_type_t {
   p_help = "WIND for Samurai wind analysis, THERMO for Thermo analysis from samurai output file, WIND_THERMO for Wind and then Thermo analysis (in-memory)"
 } analysis_type;
 
+paramdef int {
+  p_default = -999;
+  p_descr = "number of meta-data associated with each observation";
+  p_help = "";
+} obMetaSize;
+
 typedef enum {
   PROJ_LAMBERT_CONFORMAL_CONIC,
   PROJ_TRANSVERSE_MERCATOR_EXACT


### PR DESCRIPTION
This PR partially addresses the issue #87 , where we will read in the `obMetaSize` parameter from the TDRP config file and a user can change its value based on the type of analysis run.

Only test the Beltrami case for now.