### PR TITLE
Set numVars and obMetaSize at one fixed place

### DIFF
--- a/src/CostFunction3D.cpp
+++ b/src/CostFunction3D.cpp
@@ -136,12 +136,13 @@ void CostFunction3D::finalize()
 }
 
 void CostFunction3D::initialize(HashMap* config,
-				real* bgU, real* obs, ReferenceState* ref)
+				real* bgU, real* obs, ReferenceState* ref,
+        uint64_t numVar, int numDerivatives, int numObMetaData)
 {
   // Initialize number of variables
-  varDim     = 7;
-  derivDim   = 4;
-  obMetaSize = 7;
+  varDim     = numVar;
+  derivDim   = numDerivatives;
+  obMetaSize = numObMetaData;
   configHash = config;
 
   /* Set the output path */

--- a/src/CostFunction3D.h
+++ b/src/CostFunction3D.h
@@ -23,7 +23,7 @@
 #include <iterator>
 #include <vector>
 #include <string>
-#include <string>
+#include <cstdint>
 #include <unordered_map>
 //#include <complex.h>
 
@@ -42,7 +42,7 @@ public:
 
 CostFunction3D(const Projection& proj, const int& numObs = 0, const int& stateSize = 0);
 	virtual ~CostFunction3D();
-    void initialize(HashMap* config, real* bgU, real* obs, ReferenceState* ref);
+    void initialize(HashMap* config, real* bgU, real* obs, ReferenceState* ref, uint64_t numVar, int numDerivatives, int numObMetaData);
 	void finalize();
 	void updateBG();
 	void initState(const int iteration);

--- a/src/VarDriver3D.cpp
+++ b/src/VarDriver3D.cpp
@@ -31,9 +31,9 @@
 // Constructor
 VarDriver3D::VarDriver3D() : VarDriver()
 {
-  numVars = 7;          // Number of variables on which to perform the anslysis
+  numVars = -1;          // Set in the validateDriver() function
   numDerivatives = 4;
-  obMetaSize = 7;       // Size of the observation Meta data
+  obMetaSize = -1;       // Set in the validateDriver() function
   bkgdAdapter = NULL;
   bgU = NULL;
   bgWeights = NULL;
@@ -104,6 +104,16 @@ bool VarDriver3D::validateDriver()
 
    // Print the analysis_type from the TDRP config file
   std::cout << "Analysis type: " << configHash["analysis_type"] << std::endl;
+  if (configHash["analysis_type"] == "WIND")
+  {
+    numVars = 7;          // Number of variables on which to perform the anslysis
+    obMetaSize = 7;       // Size of the observation Meta data
+  }
+  if (configHash["analysis_type"] == "THERMO")
+  {
+	numVars = 3;          // Number of variables on which to perform the anslysis
+	obMetaSize = 7;       // Size of the observation Meta data
+  }
    if(configHash["analysis_type"] != "WIND")
    {
 	   std::cout << "i_pip_bcL = " << configHash["i_pip_bcL"] << std::endl;
@@ -2327,7 +2337,7 @@ bool VarDriver3D::adjustBackground()
   } else if (runMode == RTZ) {
     bgCost3D = new CostFunctionRTZ(projection, numbgObs, bStateSize);
   }
-  bgCost3D->initialize(&configHash, bgU, bgObs, refstate);
+  bgCost3D->initialize(&configHash, bgU, bgObs, refstate, numVars, numDerivatives, obMetaSize);
 
   // Set the iteration to zero --
   // this will prevent writing the background file until after the adjustment
@@ -2895,7 +2905,7 @@ bool VarDriver3D::initObCost3D()
     obCost3D = new CostFunctionRTZ(projection, obVector.size(), bStateSize);
   }
 
-  obCost3D->initialize(&configHash, bgU, obs, refstate);
+  obCost3D->initialize(&configHash, bgU, obs, refstate, numVars, numDerivatives, obMetaSize);
   return true;
 }
 


### PR DESCRIPTION
This PR sets the `numVars` and `obMetaSize` variables at a fixed place based on the analysis type.

fix #87 