### PR TITLE
Addresses issue when running Samurai-TR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(SOLVER_CG_EPSILON 1.0e-18)
 set(SOLVER_CG_BETA_TYPE 2)
 
 # type of convergenve for Samurai CG(1 = ~step size(orig), 2 = ||g(X)||/||g(X0)||)
-set(SOLVER_CG_CONV_TYPE 1)
+set(SOLVER_CG_CONV_TYPE 2)
 
 # Controls whether to just do the I/O portion of the run; this is just for testing
 set(IO_BENCHMARK 0)

--- a/ncar_scripts/TDRP/beltramiTR.tdrp
+++ b/ncar_scripts/TDRP/beltramiTR.tdrp
@@ -33,7 +33,7 @@ debug_kd_step = 0;
 //
 // Type: string
 
-wind_file = "../ncar_scripts/input/beltrami_test_v2.nc";
+wind_file = "../ncar_scripts/input/beltrami_test_updatedsounding.nc";
 
 //======================================================================
 //

--- a/src/VarDriver3D.cpp
+++ b/src/VarDriver3D.cpp
@@ -110,7 +110,7 @@ bool VarDriver3D::validateDriver()
       obMetaSize = 7;       // Size of the observation Meta data
       analysisMode = VarDriver::WIND;
   } else if (configHash["analysis_type"] == "THERMO") {
-      numVars = 3;          // Number of variables on which to perform the anslysis
+      numVars = 7;          // Number of variables on which to perform the anslysis
       obMetaSize = 7;       // Size of the observation Meta data
       analysisMode = VarDriver::THERMO;
   } else {


### PR DESCRIPTION
This PR addresses an issue in the construction of the observation vector that was creating non-checkboard solutions.  It also updates the output of Samurai-WIND and uses the correct convergence criterion.
